### PR TITLE
PLT-3005: Remove link to docs in integration confirmations screen

### DIFF
--- a/webapp/components/integrations/components/confirm_integration.jsx
+++ b/webapp/components/integrations/components/confirm_integration.jsx
@@ -205,7 +205,7 @@ export default class ConfirmIntegration extends React.Component {
                     <div className='backstage-list__help'>
                         <FormattedHTMLMessage
                             id='add_oauth_app.doneUrlHelp'
-                            defaultMessage='Please send data to the following URL (see <a href="https://docs.mattermost.com/developer/oauth2-applications.html">documentation</a> for further details.)'
+                            defaultMessage='Please send data to the following URL.'
                         />
                     </div>
                 );

--- a/webapp/i18n/en.json
+++ b/webapp/i18n/en.json
@@ -105,7 +105,7 @@
   "add_oauth_app.nameRequired": "Name for the OAuth 2.0 application is required.",
   "add_oauth_app.trusted.help": "When true, the OAuth 2.0 application is considered trusted by the Mattermost server and doesn't require the user to accept authorization. When false, an additional window will appear, asking the user to accept or deny the authorization.",
   "add_oauth_app.doneHelp": "Your OAuth 2.0 application has been set up. Please use the following Client ID and Client Secret when requesting authorization for your application.",
-  "add_oauth_app.doneUrlHelp": "Please send data to the following URL (see <a href=\"https://docs.mattermost.com/developer/oauth2-applications.html\">documentation</a> for further details.)",
+  "add_oauth_app.doneUrlHelp": "Please send data to the following URL.",
   "add_oauth_app.clientId": "Client ID: {id}",
   "add_oauth_app.clientSecret": "Client Secret: {secret}",
   "add_oauth_app.url": "URL(s): {url}",


### PR DESCRIPTION
Remove link to docs in integration confirmations screen: https://github.com/mattermost/platform/pull/3747/files
#### Checklist
- [X] Includes text changes and localization files updated
